### PR TITLE
Substituted enoms in place of strings for events

### DIFF
--- a/pkg/sdk/api_internal.go
+++ b/pkg/sdk/api_internal.go
@@ -92,7 +92,7 @@ func (wfInst *workflowInstance) handleEvent(eventWrapper EventWrapper) error {
     log.Debug("Handling event of type ", eventWrapper.ParsedMsg["_type"])
     // call the appropriate handler function, if it was set by the user implementation
     switch eventWrapper.EventName {
-        case "start":
+        case START:
             var params StartEvent
             json.Unmarshal(eventWrapper.Msg, &params)
 
@@ -101,7 +101,7 @@ func (wfInst *workflowInstance) handleEvent(eventWrapper EventWrapper) error {
             } else {
                 log.Debug("ignoring event", eventWrapper.EventName, "no handler registered")                
             }
-        case "interaction_lifecycle":
+        case INTERACTION_LIFECYCLE:
             log.Debug("interaction lifecycle event:", string(eventWrapper.Msg))
             var params InteractionLifecycleEvent
             json.Unmarshal(eventWrapper.Msg, &params)
@@ -110,7 +110,7 @@ func (wfInst *workflowInstance) handleEvent(eventWrapper EventWrapper) error {
             } else {
                 log.Debug("ignoring event", eventWrapper.EventName, "no handler registered")                
             }
-        case "prompt":
+        case PROMPT:
             var params PromptEvent
             json.Unmarshal(eventWrapper.Msg, &params)
             log.Debug("prompt event: ", params)
@@ -119,7 +119,7 @@ func (wfInst *workflowInstance) handleEvent(eventWrapper EventWrapper) error {
             } else {
                 log.Debug("ignoring event", eventWrapper.EventName, "no handler registered")                
             }
-        case "button":
+        case BUTTON:
             log.Debug("button event ", string(eventWrapper.Msg))
             var params ButtonEvent
             json.Unmarshal(eventWrapper.Msg, &params)
@@ -128,12 +128,12 @@ func (wfInst *workflowInstance) handleEvent(eventWrapper EventWrapper) error {
             } else {
                 log.Debug("ignoring event ", eventWrapper.EventName, "no handler registered")                
             }
-        case "stop":
+        case STOP:
             log.Info("Workflow instance terminating, reason: ", eventWrapper.ParsedMsg["reason"])
             var params StopEvent
             json.Unmarshal(eventWrapper.Msg, &params)
             wfInst.StopReason = params.Reason
-        case "timer_fired":
+        case TIMER_FIRED:
             log.Debug("received timer fired event")
             var params TimerFiredEvent
             json.Unmarshal(eventWrapper.Msg, &params)
@@ -142,7 +142,7 @@ func (wfInst *workflowInstance) handleEvent(eventWrapper EventWrapper) error {
             } else {
                 log.Debug("ignoring event ", eventWrapper.EventName, " no handler registered")                
             }
-        case "timer":
+        case TIMER:
             log.Debug("received timer event ", string(eventWrapper.Msg))
             var params TimerEvent
             json.Unmarshal(eventWrapper.Msg, &params)
@@ -151,7 +151,7 @@ func (wfInst *workflowInstance) handleEvent(eventWrapper EventWrapper) error {
             } else {
                 log.Debug("ignoring event ", eventWrapper.EventName, " no handler registered")
             }
-        case "speech":
+        case SPEECH:
             log.Debug("received speech event ", string(eventWrapper.Msg))
             var params SpeechEvent
             json.Unmarshal(eventWrapper.Msg, &params)

--- a/pkg/sdk/sdk.go
+++ b/pkg/sdk/sdk.go
@@ -109,10 +109,10 @@ func parseMessage(msg []byte) (map[string]interface{}, Event, string) {
     msgType := parsedMsg["_type"].(string)
     if eventRegex.MatchString(msgType) {
         matches = eventRegex.FindStringSubmatch(msgType)
-        messageType = "event"
+        messageType = EVENT
     } else {
         matches = responseRegex.FindStringSubmatch(msgType)
-        messageType = "response"
+        messageType = RESPONSE
     }
     
     return parsedMsg, Event(matches[1]), messageType

--- a/pkg/sdk/types.go
+++ b/pkg/sdk/types.go
@@ -13,6 +13,7 @@ const(
     SPEECH = "speech"
     NOTIFICATION = "notification"
     INCIDENT = "incident"
+    PROMPT = "prompt"
     PROMPT_START = "prompt_start"
     PROMPT_STOP = "prompt_stop"
     CALL_RINGING = "call_ringing"
@@ -21,6 +22,7 @@ const(
     CALL_FAILED = "call_failed"
     CALL_RECEIVED = "call_received"
     CALL_START_REQUEST = "call_start_request"
+    TIMER_FIRED = "timer_fired"
 )
 
 type TriggerType string
@@ -33,6 +35,12 @@ const (
 	CALENDAR_TRIGGER = "calendar"
 	GEOFENCE_TRIGGER = "geofence"
 	TELEPHONY_TRIGGER = "telephony"
+)
+
+type MessageType string 
+const (
+    EVENT = "event"
+    RESPONSE = "response"
 )
 
 type Language string 

--- a/pkg/sdk/ws_receiver.go
+++ b/pkg/sdk/ws_receiver.go
@@ -28,18 +28,18 @@ func (wfInst *workflowInstance) receiveWs() {
         eventWrapper := EventWrapper{ParsedMsg: parsedMsg, Msg: msg, EventName: eventName}
         
         // including speech event so that it can be passed to handleResponse for a listen API call
-        if messageType == "response" || eventName == "speech" {
+        if messageType == RESPONSE || eventName == SPEECH {
             // pair with callback
             err = wfInst.handleResponse(EventWrapper{ParsedMsg: parsedMsg, Msg: msg, EventName: eventName})
             if err != nil {
                 log.Debug("Error from response handler ", err)
                 return
             }
-        } else if messageType == "event" {
+        } else if messageType == EVENT {
             // send events to event channel
             select {
                 case wfInst.EventChannel <- eventWrapper:
-                    if eventName == "prompt" && eventWrapper.ParsedMsg["type"].(string) == "stopped" {
+                    if eventName == PROMPT && eventWrapper.ParsedMsg["type"].(string) == "stopped" {
                         streamingComplete = true
                     }
 


### PR DESCRIPTION
Replaced strings throughout the program with their corresponding enum values.  Mainly used for event types (prompt, start) or message types (response or event) from the server.