### PR TITLE
remove convert workaround

### DIFF
--- a/pkg/sdk/sdk.go
+++ b/pkg/sdk/sdk.go
@@ -117,12 +117,3 @@ func parseMessage(msg []byte) (map[string]interface{}, Event, string) {
     
     return parsedMsg, Event(matches[1]), messageType
 }
-
-func convert(arr []interface{}) string {
-    var bytes []byte = make([]byte, len(arr))
-    for i, v := range arr {
-        var f float64 = v.(float64)
-        bytes[i] = byte(f)
-    }
-    return string(bytes)
-}


### PR DESCRIPTION
For ticket [PE-19339](https://republic-bts.atlassian.net/browse/PE-19339), we are now able to remove the workarounds we had in place for converting the char array to a string.  I removed the convert() function that does this and checked that it is not used in any of the other files for the golang SDK (I think I removed this workaround from the other files back when I first started updating the golang SDK). 